### PR TITLE
Changed Control Manifest to allow different types

### DIFF
--- a/ActionButton/ActionButton/ControlManifest.Input.xml
+++ b/ActionButton/ActionButton/ControlManifest.Input.xml
@@ -1,9 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <manifest>
   <control namespace="MscrmTools" constructor="ActionButton" version="0.0.4" display-name-key="ActionButton_Display_Key" description-key="ActionButton_Desc_Key" control-type="standard" preview-image="imgs/logo.png">
     <!-- property node identifies a specific, configurable piece of data that the control expects from CDS -->
-    <property name="BoundAttribute" display-name-key="BoundAttribute_Display_Key" description-key="BoundAttribute_Desc_Key" of-type="SingleLine.Text" usage="bound" required="true" />
+    <property name="BoundAttribute" display-name-key="BoundAttribute_Display_Key" description-key="BoundAttribute_Desc_Key" of-type-group="typeAction" usage="bound" required="true" />
     <property name="ActionText" display-name-key="ActionText_Display_Key" description-key="ActionText_Desc_Key" of-type="SingleLine.Text" default-value="" usage="input" required="false" />
+    <type-group name="typeAction">
+      <type>SingleLine.Text</type>
+      <type>DateAndTime.DateAndTime</type>
+      <type>DateAndTime.DateOnly</type>
+      <type>Decimal</type>
+      <type>SingleLine.TextArea</type>
+      <type>Whole.None</type>
+    </type-group>
     <!-- <property name="SetAsFormState" display-name-key="SetAsFormState_Display_Key" description-key="SetAsFormState_Desc_Key" of-type="Enum" usage="input" default-value="True" required="true">
       <value name="True" display-name-key="true_Display_Key" description-key="true_Desc_Key">True</value>
       <value name="False" display-name-key="false_Display_Key" description-key="false_Desc_Key">False</value>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,17 @@ Controls using PowerApps Components Framework
 [Download](https://github.com/MscrmTools/PCF-Controls/releases/)
 
 ### Purpose
-The purpose of this control is to allow user to associate/disassociate records for a many-to-many relationship displaying all possible records as checkboxes or toggle switches
+Allows to display a button to perform an action. To allow developer to do anything they want from the form, this button simply copies the text of the action button on the bound attribute. 
+
+This can be one of the following types:
+- SingleLine.Text
+- DateAndTime.DateAndTime
+- DateAndTime.DateOnly
+- Decimal
+- Whole.None
+- SingleLine.TextArea
+
+The developer needs to add an onChange event to this string attribute, check for the value of the attribute (should be the text of the action button) and perform the action needed.
 
 ![Vidéo](https://github.com/MscrmTools/PCF-Controls/blob/master/NNCheckboxes/Screenshots/video.gif?raw=true)
 


### PR DESCRIPTION
Based on issue #24 I have updated the Control Manifest and the Readme in order to allow the following types:

- SingleLine.Text
- DateAndTime.DateAndTime
- DateAndTime.DateOnly
- Decimal
- Whole.None
- SingleLine.TextArea

Hopefully this makes sense and works for you, so you can close the ticket I opened