### PR TITLE
Standardised the error messaging in NN Checkboxes

### DIFF
--- a/NNCheckboxes/NNCheckboxes/ControlManifest.Input.xml
+++ b/NNCheckboxes/NNCheckboxes/ControlManifest.Input.xml
@@ -17,6 +17,10 @@
     </property>
     <property name="toggleDefaultBackgroundColorOff" display-name-key="toggleDefaultBackgroundColorOff_Display_Key" description-key="toggleDefaultBackgroundColorOff_Desc_Key" of-type="SingleLine.Text" usage="input" required="false" default-value="#CC0000" />
     <property name="toggleDefaultBackgroundColorOn" display-name-key="toggleDefaultBackgroundColorOn_Display_Key" description-key="toggleDefaultBackgroundColorOn_Desc_Key" of-type="SingleLine.Text" usage="input" required="false" default-value="#008800" />
+    <property name="showCustomErrors" display-name-key="showCustomErrors_Display_Key" description-key="showCustomErrors_Desc_Key" of-type="Enum" usage="input" required="true" default-value="0">
+      <value name="Yes" display-name-key="yes_Display_Key" description-key="yes_Desc_Key">1</value>
+      <value name="No" display-name-key="no_Display_Key" description-key="no_Desc_Key" default="true">0</value>
+    </property>
     <property name="addCategorySelector" display-name-key="addCategorySelector_Display_Key" description-key="addCategorySelector_Desc_Key" of-type="Enum" default-value="0" usage="input" required="true">
       <value name="Yes" display-name-key="yes_Display_Key" description-key="yes_Desc_Key">1</value>
       <value name="No" display-name-key="no_Display_Key" description-key="no_Desc_Key">0</value>

--- a/NNCheckboxes/NNCheckboxes/strings/NNCheckboxes.1033.resx
+++ b/NNCheckboxes/NNCheckboxes/strings/NNCheckboxes.1033.resx
@@ -127,12 +127,6 @@
     <data name="categoryAttribute_Desc_Key" xml:space="preserve">
         <value>Attribute used to group records. This attribute must be exposed in the selected view</value>
     </data>
-    <data name="No_Relationship_Found" xml:space="preserve">
-        <value>No many-to-many relationship has been found for these entities</value>
-    </data>
-    <data name="Multiple_Relationships_Found" xml:space="preserve">
-        <value>Mutliple many-to-many relationships have been found for these entities. Please define the relationship in this control configuration</value>
-    </data>
     <data name="No_Category" xml:space="preserve">
         <value>Uncategorized records</value>
     </data>
@@ -178,11 +172,35 @@
     <data name="fpa_Desc_Key" xml:space="preserve">
         <value>Filter attribute for parent record. Must be of the same type as the filter for the related records </value>
     </data>
-    <data name="Error_Retrieve_Records" xml:space="preserve">
-        <value>An error occured when retrieving records</value>
+    <data name="showCustomErrors_Display_Key" xml:space="preserve">
+        <value>Show custom errors</value>
     </data>
-    <data name="No_Relationship_Found_For_Provided_SchemaName" xml:space="preserve">
-        <value>No relationship has been found with the provided schema name in configuration</value>
+    <data name="showCustomErrors_Desc_Key" xml:space="preserve">
+        <value>Whether or not to show custom errors from the platform (ie synchronous plugin exception messages) [Yes] or to instead show a generic error message [No].</value>
+    </data>
+    <data name="Error_Generic" xml:space="preserve">
+        <value>NNCheckboxes: An error occured. Please check this control configuration or any applicable trace logs.</value>
+    </data>
+    <data name="Error_Retrieve_Records" xml:space="preserve">
+        <value>NNCheckboxes: An error occured when retrieving records for the relationship. Please check NNCheckboxes control configuration.</value>
+    </data>
+    <data name="Error_Retrieve_View" xml:space="preserve">
+        <value>NNCheckboxes: An error occured when retrieving the view for the relationship. Please check NNCheckboxes control configuration.</value>
+    </data>
+    <data name="Error_No_Relationship_Found_For_Provided_SchemaName" xml:space="preserve">
+        <value>NNCheckboxes: No relationship has been found with the provided schema name in configuration.</value>
+    </data>
+    <data name="Error_No_Relationship_Found" xml:space="preserve">
+        <value>NNCheckboxes: No many-to-many relationship has been found for these entities.</value>
+    </data>
+    <data name="Error_Multiple_Relationships_Found" xml:space="preserve">
+        <value>NNCheckboxes: Multiple many-to-many relationships have been found for these entities. Please define the relationship in this control configuration.</value>
+    </data>
+    <data name="Error_Associate" xml:space="preserve">
+        <value>NNCheckboxes: An error occured when associating records. Please check this control configuration or any applicable trace logs.</value>
+    </data>
+    <data name="Error_Disassociate" xml:space="preserve">
+        <value>NNCheckboxes: An error occured when disassociating records. Please check this control configuration or any applicable trace logs.</value>
     </data>
     <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
 </root>

--- a/NNCheckboxes/NNCheckboxes/strings/NNCheckboxes.1036.resx
+++ b/NNCheckboxes/NNCheckboxes/strings/NNCheckboxes.1036.resx
@@ -127,12 +127,6 @@
     <data name="columnsNumber_Desc_Key" xml:space="preserve">
         <value>Nombre de colonnes à utiliser pour afficher les enregistrements</value>
     </data>
-    <data name="No_Relationship_Found" xml:space="preserve">
-        <value>Aucune relation plusieurs à plusieurs n'a été trouvé pour ces entités</value>
-    </data>
-    <data name="Multiple_Relationships_Found" xml:space="preserve">
-        <value>Plusieurs relations plusieurs à plusieurs ont été trouvé pour ces entités. Veuillez spécifier le nom de schéma de la relation à utiliser dans la configuration de ce contrôle</value>
-    </data>
     <data name="No_Category" xml:space="preserve">
         <value>Enregistrements non catégorisés</value>
     </data>
@@ -178,14 +172,35 @@
     <data name="fpa_Desc_Key" xml:space="preserve">
         <value>Attribut de l'enregistrement parent permettant de filtrer les enregistrements</value>
     </data>
+    <data name="showCustomErrors_Display_Key" xml:space="preserve">
+        <value>Afficher les erreurs personnalisées</value>
+    </data>
+    <data name="showCustomErrors_Desc_Key" xml:space="preserve">
+        <value>Afficher ou non les erreurs personnalisées de la plate-forme (c'est-à-dire les messages d'exception de plug-in synchrones) [Oui] ou afficher à la place un message d'erreur générique [Non].</value>
+    </data>
+    <data name="Error_Generic" xml:space="preserve">
+        <value>NN Cases à cocher : une erreur s'est produite. Veuillez vérifier cette configuration de contrôle ou tout journal de suivi applicable.</value>
+    </data>
     <data name="Error_Retrieve_Records" xml:space="preserve">
         <value>Une erreur est survenue lors de la recherche des enregistrements</value>
     </data>
     <data name="Error_Retrieve_View" xml:space="preserve">
         <value>Une erreur est survenue lors de la récupération de la vue courante</value>
     </data>
-    <data name="No_Relationship_Found_For_Provided_SchemaName" xml:space="preserve">
+    <data name="Error_No_Relationship_Found_For_Provided_SchemaName" xml:space="preserve">
         <value>Aucune relation n'a été trouvée avec le nom de schéma fourni dans la configuration</value>
+    </data>
+    <data name="Error_No_Relationship_Found" xml:space="preserve">
+        <value>Aucune relation plusieurs à plusieurs n'a été trouvé pour ces entités</value>
+    </data>
+    <data name="Error_Multiple_Relationships_Found" xml:space="preserve">
+        <value>Plusieurs relations plusieurs à plusieurs ont été trouvé pour ces entités. Veuillez spécifier le nom de schéma de la relation à utiliser dans la configuration de ce contrôle</value>
+    </data>
+    <data name="Error_Associate" xml:space="preserve">
+        <value>NN Cases à cocher : une erreur s'est produite lors de l'association d'enregistrements. Veuillez vérifier cette configuration de contrôle ou tout journal de suivi applicable.</value>
+    </data>
+    <data name="Error_Disassociate" xml:space="preserve">
+        <value>Cases à cocher NN : une erreur s'est produite lors de la dissociation des enregistrements. Veuillez vérifier cette configuration de contrôle ou tout journal de suivi applicable.</value>
     </data>
     <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
 </root>


### PR DESCRIPTION
### Generalised NN Checkboxes Error Messaging
#### Core Reason
Ability to surface synchronous Associate/Disassociate plugin errors to the user, with the goal of being able to better inform end users of business logic reasoning behind some failed associate / dissassociations.
#### Key Changes
* Grouped existing error messages together in resources file + added "Error" prefix.
* Added new generic error fallback message (English French - please check French as I just used Google Translate)
* Added new "DisplayError" private function to translate the error object.
* Added new "Custom Error" parameter to the configuration.
  * Default is No, essentially prints generic error messages like it does now. Any error object messages are passed in the downloadable details log text file.
![legacy-generic-errors](https://user-images.githubusercontent.com/62692181/134445345-6e08a27c-ab06-40a8-a46b-f716d5c93a9f.png)
  * Alternative new Yes mode, will print the custom error object message to the primary modal dialog.
![new-custom-errors](https://user-images.githubusercontent.com/62692181/134445370-102186d5-1566-4a2c-a928-87bcad15f595.png)

New Parameter (Defaults to No):
![new-param](https://user-images.githubusercontent.com/62692181/134445764-f5e614c5-ffab-4096-ba75-bf409c8fd897.png)
