### PR TITLE
Handle Disabled (ReadOnly) status change.

### DIFF
--- a/CustomSwitch/CustomSwitch/index.ts
+++ b/CustomSwitch/CustomSwitch/index.ts
@@ -139,6 +139,12 @@ export class CustomSwitch implements ComponentFramework.StandardControl<IInputs,
 
 			this.ensureLabel((<HTMLInputElement>document.getElementById(this._checkboxid)).checked);
 		}
+		
+		if (context.mode.isControlDisabled) {
+			(<HTMLInputElement>document.getElementById(this._checkboxid)).setAttribute("disabled", "disabled");
+		}else{
+			(<HTMLInputElement>document.getElementById(this._checkboxid)).removeAttribute("disabled")
+		}
 	}
 
 	/** 


### PR DESCRIPTION
Quick Patch to react to Disabled/Enabled status change when it's modified via JS on the form.

It solves issue #151 by updating the control input element to lock/unluck the toggle when JS/BR modified the field parameter Disabled.