### PR TITLE
Fix styling bleed from NNCheckboxes to other PCF

### DIFF
--- a/NNCheckboxes/NNCheckboxes/css/NNCheckboxes.css
+++ b/NNCheckboxes/NNCheckboxes/css/NNCheckboxes.css
@@ -11,7 +11,7 @@ input[type=checkbox] + label {
 
 input[type=checkbox]:checked + label{
     font-weight: normal;
-    text-decoration: line-through;
+    /* text-decoration: line-through; */
 }
 
 

--- a/NNCheckboxes/NNCheckboxes/css/NNCheckboxes.css
+++ b/NNCheckboxes/NNCheckboxes/css/NNCheckboxes.css
@@ -1,7 +1,7 @@
 body {
     margin: 0;
 }
-
+/* 
 input[type=checkbox] + label {
     vertical-align: middle;
     position: relative;
@@ -11,9 +11,9 @@ input[type=checkbox] + label {
 
 input[type=checkbox]:checked + label{
     font-weight: normal;
-    /* text-decoration: line-through; */
+     text-decoration: line-through;  
 }
-
+*/
 
 div.nncb-main{
     margin-top:10px;


### PR DESCRIPTION
This comments out two classes that have been impacting another PCF and don't seem to be in use by the NNCheckbox control any longer (and were in the original CSS committed 5+ years ago).

Per image below, the styles were impacting another PCF (in yellow) but were not applied to the NNCheckbox control. I have applied these changes in our environment successfully.

![image](https://github.com/user-attachments/assets/5bef3ef3-3bf8-4cab-92a4-8b3a3589d65e)

I haven't done any updates to version numbers or rebuilt the control.